### PR TITLE
Make composer requirements more strict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": "^7.2 || ^8.0",
     "ext-pdo": "*",
-    "doctrine/dbal": ">=2.10"
+    "doctrine/dbal": "^2.10"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
This prevents installing versions that are not supported yet.